### PR TITLE
HTTPS Support

### DIFF
--- a/incubator/codedx/templates/NOTES.txt
+++ b/incubator/codedx/templates/NOTES.txt
@@ -4,4 +4,26 @@ The password for the Code Dx database root user is {{ .Values.rootUserDatabasePa
 
 The Code Dx admin password is {{ .Values.codedxAdminPassword }}.
 
+{{- if not (include "codedx.license.exists" .) }}
+
+No license was provided during installation - you'll need to provide one when accessing Code Dx for the first time.
+
+{{- end }}
+
+{{ if .Values.ingress.enabled -}}
+Code Dx will be available at the following URLs:
+{{ range .Values.ingress.hosts }}
+{{- if .tls -}}
+- https://{{ .name }}/codedx
+{{ else -}}
+- http://{{ .name }}/codedx
+{{ end -}}
+{{- end -}}
+{{- else -}}
 Code Dx will be available on port {{ .Values.codedxTomcatPort }}.
+{{- end }}
+
+Code Dx can be customized by editing the {{ include "codedx.props.configMapName" . | quote }} config map and
+starting a new pod to reload the changes. If you want to add more Code Dx configuration properties as secrets,
+mount the secret as a file to Code Dx and give the file path to Code Dx by modifying the `tomcat.env` key of
+the {{ include "codedx.props.configMapName" . | quote }} config map.

--- a/incubator/codedx/templates/_helpers.tpl
+++ b/incubator/codedx/templates/_helpers.tpl
@@ -38,3 +38,15 @@ Create chart name and version as used by the chart label.
 {{- define "codedx.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "codedx.servicetype" -}}
+{{- if and (.Values.service) (default "" .Values.service.type) -}}
+{{- .Values.service.type -}}
+{{- else }}
+{{- if .Values.ingress.enabled -}}
+{{- "ClusterIP" }}
+{{- else -}}
+{{- "LoadBalancer" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/codedx/templates/_helpers.tpl
+++ b/incubator/codedx/templates/_helpers.tpl
@@ -52,7 +52,7 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "codedx.license.exists" -}}
-{{- or .Values.codedx.license.secret .Values.codedx.license.file -}}
+{{- or (default "" .Values.codedx.license.secret) (default "" .Values.codedx.license.file) -}}
 {{- end -}}
 
 {{- define "codedx.license.secretName" -}}

--- a/incubator/codedx/templates/codedx-ingress-secrets.yaml
+++ b/incubator/codedx/templates/codedx-ingress-secrets.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/component: "ingress"
 type: kubernetes.io/tls
 data:
-  tls.key: {{ .key | replace " " "" | trim }}
-  tls.crt: {{ .certificate | replace " " "" | trim }}
+  tls.key: {{ .key | trim }}
+  tls.crt: {{ .certificate | trim }}
 ---
 {{- end -}}
 {{- end -}}

--- a/incubator/codedx/templates/codedx-ingress-secrets.yaml
+++ b/incubator/codedx/templates/codedx-ingress-secrets.yaml
@@ -5,7 +5,10 @@ kind: Secret
 metadata:
   name: {{ .name }}
   labels:
+    app.kubernetes.io/name: {{ include "codedx.name" . }}
     helm.sh/chart: {{ include "codedx.chart" $ }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: "ingress"
 type: kubernetes.io/tls
 data:

--- a/incubator/codedx/templates/codedx-ingress-secrets.yaml
+++ b/incubator/codedx/templates/codedx-ingress-secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ingress.enabled -}}
+{{- range .Values.ingress.secrets -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    helm.sh/chart: {{ include "codedx.chart" $ }}
+    app.kubernetes.io/component: "ingress"
+type: kubernetes.io/tls
+data:
+  tls.key: {{ .key | replace " " "" | trim }}
+  tls.crt: {{ .certificate | replace " " "" | trim }}
+---
+{{- end -}}
+{{- end -}}

--- a/incubator/codedx/templates/codedx-ingress.yaml
+++ b/incubator/codedx/templates/codedx-ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{ if $.Values.ingress.autoRedirect -}}
     nginx.ingress.kubernetes.io/app-root: /codedx
     {{- end }}
+    {{ if not .tls -}}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
     # Increase timeout duration for Code Dx live updates
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
 spec:

--- a/incubator/codedx/templates/codedx-ingress.yaml
+++ b/incubator/codedx/templates/codedx-ingress.yaml
@@ -10,7 +10,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/component: "ingress"
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /codedx
+    # Note - In my testing these annotations didn't actually have any affect on the NGINX
+    #        ingress controller, and neither does the "path" property on the "rules"
+    #        attribute (at least for this configuration)
+
+    ingress.kubernetes.io/rewrite-target: "/codedx"
+    nginx.ingress.kubernetes.io/rewrite-target: "/codedx"
 spec:
   {{- if .tls }}
   tls:
@@ -23,7 +28,7 @@ spec:
   - host: {{ .name }}
     http:
       paths:
-      - path: {{ default "/codedx/*" .path }}
+      - path: {{ default "/codedx" .path }}
         backend:
           serviceName: {{ include "codedx.fullname" $ }}
           servicePort: {{ $.Values.codedxTomcatPort }}

--- a/incubator/codedx/templates/codedx-ingress.yaml
+++ b/incubator/codedx/templates/codedx-ingress.yaml
@@ -11,11 +11,11 @@ metadata:
     app.kubernetes.io/component: "ingress"
     app.kubernetes.io/part-of: codedx
   annotations:
-    {{ if .Values.ingress.autoRedirect -}}
+    {{ if $.Values.ingress.autoRedirect -}}
     nginx.ingress.kubernetes.io/app-root: /codedx
     {{- end }}
     # Increase timeout duration for Code Dx live updates
-    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
 spec:
   {{- if .tls }}
   tls:

--- a/incubator/codedx/templates/codedx-ingress.yaml
+++ b/incubator/codedx/templates/codedx-ingress.yaml
@@ -9,13 +9,13 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/component: "ingress"
+    app.kubernetes.io/part-of: codedx
   annotations:
-    # Note - In my testing these annotations didn't actually have any affect on the NGINX
-    #        ingress controller, and neither does the "path" property on the "rules"
-    #        attribute (at least for this configuration)
-
-    ingress.kubernetes.io/rewrite-target: "/codedx"
-    nginx.ingress.kubernetes.io/rewrite-target: "/codedx"
+    {{ if .Values.ingress.autoRedirect -}}
+    nginx.ingress.kubernetes.io/app-root: /codedx
+    {{- end }}
+    # Increase timeout duration for Code Dx live updates
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
 spec:
   {{- if .tls }}
   tls:
@@ -28,7 +28,7 @@ spec:
   - host: {{ .name }}
     http:
       paths:
-      - path: {{ default "/codedx" .path }}
+      - path: /codedx
         backend:
           serviceName: {{ include "codedx.fullname" $ }}
           servicePort: {{ $.Values.codedxTomcatPort }}

--- a/incubator/codedx/templates/codedx-ingress.yaml
+++ b/incubator/codedx/templates/codedx-ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- range .Values.ingress.hosts -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-%s" (include "codedx.name" $) .name | trunc 63 | trimSuffix "-" | quote }}
+  labels:
+    helm.sh/chart: {{ include "codedx.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/component: "ingress"
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /codedx
+spec:
+  {{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+  {{- end }}
+
+  rules:
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/codedx/*" .path }}
+        backend:
+          serviceName: {{ include "codedx.fullname" $ }}
+          servicePort: {{ $.Values.codedxTomcatPort }}
+---
+{{- end -}}
+{{- end -}}

--- a/incubator/codedx/templates/codedx-tomcat-deployment.yaml
+++ b/incubator/codedx/templates/codedx-tomcat-deployment.yaml
@@ -38,6 +38,19 @@ spec:
           value: {{ .Values.codedxAdminPassword | quote }}
         image: {{ .Values.codedxTomcatImage | quote }}
         name: "{{ include "codedx.name" . }}"
+        readinessProbe:
+          httpGet:
+            path: /codedx/login
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /codedx/login
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          timeoutSeconds: 10
         ports:
         - containerPort: 8080
         resources: {}

--- a/incubator/codedx/templates/codedx-tomcat-deployment.yaml
+++ b/incubator/codedx/templates/codedx-tomcat-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           httpGet:
             path: /codedx/login
             port: 8080
-          initialDelaySeconds: 120
+          initialDelaySeconds: 600
           periodSeconds: 15
           timeoutSeconds: 10
         command: ["start.sh"]

--- a/incubator/codedx/templates/codedx-tomcat-service.yaml
+++ b/incubator/codedx/templates/codedx-tomcat-service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: "frontend"
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ include "codedx.servicetype" . }}
   ports:
   - name: http
     port: {{ .Values.codedxTomcatPort }}

--- a/incubator/codedx/templates/codedx-tomcat-service.yaml
+++ b/incubator/codedx/templates/codedx-tomcat-service.yaml
@@ -9,10 +9,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: "frontend"
 spec:
-  type: LoadBalancer
+  type: {{ .Values.service.type }}
   ports:
-  - name: {{ .Values.codedxTomcatPort | quote }}
+  - name: http
     port: {{ .Values.codedxTomcatPort }}
+    protocol: TCP
     targetPort: 8080
   selector:
     app.kubernetes.io/name: {{ include "codedx.name" . }}

--- a/incubator/codedx/values.yaml
+++ b/incubator/codedx/values.yaml
@@ -12,7 +12,7 @@ ingress:
   hosts:
   # - name: codedx.local
   #   tls: true
-  #   # TODO
+  #   # TODO?
   #   #certManager: true
   #   tlsSecret: tls-secret
   
@@ -22,13 +22,15 @@ ingress:
   #   key:
   #   certificate: 
 
-service:
+service: {}
   # Specify the type of service that will be exposing Code Dx. Acceptable values are:
   # ClusterIP, NodePort, LoadBalancer
   #
-  # If left unassigned, this will be "NodePort" if "ingress.enabled" is true, and "LoadBalancer" otherwise.
+  # If left unassigned, this will have one of the following defaults:
+  #   "ClusterIP"    - If "ingress.enabled" = true
+  #   "LoadBalancer" - If "ingress.enabled" = false
   #
-  type: LoadBalancer
+  #type: LoadBalancer
 
 mariadb:
   db:

--- a/incubator/codedx/values.yaml
+++ b/incubator/codedx/values.yaml
@@ -7,17 +7,25 @@ codedxTomcatPort: 9090
 rootUserDatabasePassword: 5jqJL2b8hqn3
 codedxAdminPassword: wtKzR4F8o64A
 
+# Use the `ingress` object and its properties to configure how Ingress resources are generated
+# for the new Code Dx service.
 ingress:
+  # Set `ingress.enabled` to "true" to generate an Ingress rule that forwards request to Code Dx
   enabled: false
+  # If using NGINX Ingress Controller, set this to "true" to automatically redirect any requests
+  # from `/` to `/codedx`.
   autoRedirect: true
-  hosts: {}
-  # - name: codedx.local
-  #   tls: true
-  #   # TODO?
-  #   #certManager: true
-  #   tlsSecret: tls-secret
+  # Specify the set of hosts for which to create Ingress resources
+  hosts:
+    # Specify the FQDN that Code Dx will be hosted on
+  - name: codedx.local
+    # Set `tls` to "true" to add HTTPS/TLS properties to the generated Ingress resource
+    tls: true
+    # If `tls` is "true", specifies the name of the TLS secret containing the key and certificate
+    tlsSecret: tls-secret
   
-  # Use to auto-create secrets with the given properties if they don't yet exist
+  # Use to auto-create secrets with the given properties if they don't yet exist. The values
+  # for "key" and "certificate" should be base64-encoded
   # secrets:
   # - name:
   #   key:

--- a/incubator/codedx/values.yaml
+++ b/incubator/codedx/values.yaml
@@ -107,7 +107,7 @@ codedx:
     #  key: ldap-props
 
 
-  license:
+  license: {}
     # Specify 'codedx.license.file' to automatically create a secret based on the given license
     #file: my-license-file
 
@@ -116,7 +116,7 @@ codedx:
     #
     # (If both file and secret are specified, the existing 'secret' will be used and no new secret
     #  will be created.)
-    secret: my-codedx-license-secret
+    #secret: my-codedx-license-secret
 
     # Specify annotations to attach to a generated Secret
     # annotations:

--- a/incubator/codedx/values.yaml
+++ b/incubator/codedx/values.yaml
@@ -7,6 +7,29 @@ codedxTomcatPort: 9090
 rootUserDatabasePassword: 5jqJL2b8hqn3
 codedxAdminPassword: wtKzR4F8o64A
 
+ingress:
+  enabled: false
+  hosts:
+  # - name: codedx.local
+  #   tls: true
+  #   # TODO
+  #   #certManager: true
+  #   tlsSecret: tls-secret
+  
+  # Use to auto-create secrets with the given properties if they don't yet exist
+  # secrets:
+  # - name:
+  #   key:
+  #   certificate: 
+
+service:
+  # Specify the type of service that will be exposing Code Dx. Acceptable values are:
+  # ClusterIP, NodePort, LoadBalancer
+  #
+  # If left unassigned, this will be "NodePort" if "ingress.enabled" is true, and "LoadBalancer" otherwise.
+  #
+  type: LoadBalancer
+
 mariadb:
   db:
     name: codedx

--- a/incubator/codedx/values.yaml
+++ b/incubator/codedx/values.yaml
@@ -9,7 +9,8 @@ codedxAdminPassword: wtKzR4F8o64A
 
 ingress:
   enabled: false
-  hosts:
+  autoRedirect: true
+  hosts: {}
   # - name: codedx.local
   #   tls: true
   #   # TODO?


### PR DESCRIPTION
HTTPS will not be exposed directly from Tomcat. Instead, Ingress templates have been made so that an ingress controller can provide HTTPS if necessary.

Requirements for this pull to be accepted:

- ~Move appropriate templates to `_helpers.tpl`~
- ~Double-check annotations for path forwarding~
- ~Double-check aliveness/readiness probes~
- ~Update comments in `values.yaml`~
- ~Update `NOTES.txt` appropriately~
- ~(Update `NOTES.txt` in `develop` branch appropriately)~