### PR TITLE
Specify that CREATE TEMPORARY TABLES privilege is required

### DIFF
--- a/setup/core/common/codedx.ps1
+++ b/setup/core/common/codedx.ps1
@@ -1,5 +1,5 @@
 <#PSScriptInfo
-.VERSION 1.8.2
+.VERSION 1.8.3
 .GUID 6b1307f7-7098-4c65-9a86-8478840ad4cd
 .AUTHOR Code Dx
 #>
@@ -224,7 +224,7 @@ function New-CodeDxDeploymentValuesFile([string] $codeDxDnsName,
           # Drop default privileges granted to user
           REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'codedx';
           # Grant privileges required for codedx database user
-          GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, REFERENCES, INDEX, DROP, TRIGGER ON codedx.* to 'codedx'@'%';
+          GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, CREATE TEMPORARY TABLES, ALTER, REFERENCES, INDEX, DROP, TRIGGER ON codedx.* to 'codedx'@'%';
           FLUSH PRIVILEGES;
         END IF;
       END^

--- a/setup/core/docs/db/use-external-database.md
+++ b/setup/core/docs/db/use-external-database.md
@@ -16,7 +16,7 @@ Here are the steps required to use Code Dx with an external database:
 4) Grant required privileges on the Code Dx database to the database user you created. The
    following statements grant permissions to the codedx database user.
 
-   GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, REFERENCES, INDEX, DROP, TRIGGER ON codedxdb.* to 'codedx'@'%';
+   GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, CREATE TEMPORARY TABLES, ALTER, REFERENCES, INDEX, DROP, TRIGGER ON codedxdb.* to 'codedx'@'%';
    FLUSH PRIVILEGES;
 
 5) Set the following MariaDB variables. Failure to complete this step will negatively affect Code Dx performance or functionality.


### PR DESCRIPTION
This pull request notes that a user must be granted the CREATE TEMPORARY TABLES privilege.

Related to task:  https://trello.com/c/x40vGRsK/219-job-get-and-store-triage-predictions-logs-access-denied