### PR TITLE
Add index files for Helm Charts

### DIFF
--- a/setup/core/charts/codedx-tool-orchestration/index.yaml
+++ b/setup/core/charts/codedx-tool-orchestration/index.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+entries:
+  argo:
+  - apiVersion: v2
+    appVersion: v2.12.2
+    created: "2022-11-11T17:13:14.496222088+01:00"
+    dependencies:
+    - condition: minio.install
+      name: minio
+      repository: https://kubernetes-charts.storage.googleapis.com/
+      version: 5.0.6
+    description: A Helm chart for Argo Workflows
+    digest: bcbad6b0606705d5158ec458a8449be3a49da227cb58caec5aee012ea12e67c1
+    home: https://github.com/argoproj/argo-helm
+    icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
+    maintainers:
+    - name: alexec
+    - name: alexmt
+    - name: jessesuen
+    - name: benjaminws
+    name: argo
+    urls:
+    - charts/argo-0.14.2.tgz
+    version: 0.14.2
+  codedx-tool-orchestration:
+  - apiVersion: v2
+    appVersion: 1.17.0
+    created: "2022-11-11T17:13:14.493739365+01:00"
+    dependencies:
+    - name: argo
+      repository: https://codedx.github.io/codedx-kubernetes
+      version: 0.14.2
+    - name: minio
+      repository: https://codedx.github.io/codedx-kubernetes
+      version: 3.1.8
+    description: A Helm chart for Code Dx Tool Orchestration
+    digest: 03bbb710ce255875d27056ff9b12939dea23ce9474d1d36c50daeb8a590f00dc
+    home: https://github.com/codedx/codedx-kubernetes
+    icon: https://codedx.com/wp-content/uploads/2017/03/CodeDx-logo.png
+    keywords:
+    - codedx
+    - tool
+    - orchestration
+    maintainers:
+    - email: support@codedx.com
+      name: tylercamp
+    - email: support@codedx.com
+      name: ssalas
+    name: codedx-tool-orchestration
+    urls:
+    - codedx-tool-orchestration-1.65.0.tgz
+    version: 1.65.0
+  minio:
+  - apiVersion: v1
+    appVersion: 2020.3.25
+    created: "2022-11-11T17:13:14.497709656+01:00"
+    description: MinIO is an object storage server, compatible with Amazon S3 cloud
+      storage service, mainly used for storing unstructured data (such as photos,
+      videos, log files, etc.)
+    digest: b6ce3ed4c555beb4796639cc3b7a45755b96c16d6a5be2e0f9132305d4034e06
+    home: https://min.io
+    icon: https://codedx.com/wp-content/uploads/2017/03/CodeDx-logo.png
+    keywords:
+    - minio
+    - storage
+    - object-storage
+    - s3
+    - cluster
+    maintainers:
+    - email: support@codedx.com
+      name: CodeDx
+    name: minio
+    sources:
+    - https://github.com/codedx/charts
+    urls:
+    - charts/minio-3.1.8.tgz
+    version: 3.1.8
+generated: "2022-11-11T17:13:14.489748938+01:00"

--- a/setup/core/charts/codedx/index.yaml
+++ b/setup/core/charts/codedx/index.yaml
@@ -1,9 +1,41 @@
 apiVersion: v1
 entries:
+  codedx:
+  - apiVersion: v2
+    appVersion: 2022.10.2
+    created: "2022-11-11T17:18:20.367712292+01:00"
+    dependencies:
+    - condition: mariadb.enabled
+      name: mariadb
+      repository: https://codedx.github.io/codedx-kubernetes
+      version: 7.3.20
+    description: A Helm chart for Code Dx
+    digest: b2150b17a3c024e5905c2d0fb4e29834925d2554e7f15cc3ca215410bacfb24e
+    home: https://github.com/codedx/codedx-kubernetes
+    icon: https://codedx.com/wp-content/uploads/2017/03/CodeDx-logo.png
+    keywords:
+    - codedx
+    - security
+    - sast
+    - scan
+    - analysis
+    maintainers:
+    - email: support@codedx.com
+      name: tylercamp
+    - email: support@codedx.com
+      name: ssalas
+    name: codedx
+    sources:
+    - https://hub.docker.com/r/codedx/codedx-tomcat
+    - https://hub.docker.com/_/tomcat/
+    - https://hub.docker.com/r/bitnami/mariadb
+    urls:
+    - codedx-1.77.0.tgz
+    version: 1.77.0
   mariadb:
   - apiVersion: v1
     appVersion: 10.3.25
-    created: "2022-11-11T17:12:45.054492199+01:00"
+    created: "2022-11-11T17:18:20.368880619+01:00"
     description: Fast, reliable, scalable, and easy to use open-source relational
       database system. MariaDB Server is intended for mission-critical, heavy-load
       production systems as well as for embedding into mass-deployed software. Highly
@@ -27,4 +59,4 @@ entries:
     urls:
     - charts/mariadb-7.3.20.tgz
     version: 7.3.20
-generated: "2022-11-11T17:12:45.053026958+01:00"
+generated: "2022-11-11T17:18:20.365391644+01:00"

--- a/setup/core/charts/codedx/index.yaml
+++ b/setup/core/charts/codedx/index.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+entries:
+  mariadb:
+  - apiVersion: v1
+    appVersion: 10.3.25
+    created: "2022-11-11T17:12:45.054492199+01:00"
+    description: Fast, reliable, scalable, and easy to use open-source relational
+      database system. MariaDB Server is intended for mission-critical, heavy-load
+      production systems as well as for embedding into mass-deployed software. Highly
+      available MariaDB cluster.
+    digest: 22c3c0805e7873394b61a659821885edf499c81d774e79c34e2ad00a50245335
+    home: https://mariadb.org
+    icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
+    keywords:
+    - mariadb
+    - mysql
+    - database
+    - sql
+    - prometheus
+    maintainers:
+    - email: containers@bitnami.com
+      name: Bitnami
+    name: mariadb
+    sources:
+    - https://github.com/bitnami/bitnami-docker-mariadb
+    - https://github.com/prometheus/mysqld_exporter
+    urls:
+    - charts/mariadb-7.3.20.tgz
+    version: 7.3.20
+generated: "2022-11-11T17:12:45.053026958+01:00"


### PR DESCRIPTION
In order to use the "raw" file URL as a Helm repo, there need to be `index.yaml` files available. This PR adds `index.yaml` files to both Helm Charts contained in this repository.

Why do I need this? We use ArgoCD to deploy to Kubernetes, and we can point ArgoCD directly at `https://raw.githubusercontent.com/codedx/codedx-kubernetes/master/setup/core/charts/` if these `index.yaml` files are added.
